### PR TITLE
Lat flexible tuning

### DIFF
--- a/examples/3dfd/clava/3dfd.lara
+++ b/examples/3dfd/clava/3dfd.lara
@@ -2,18 +2,19 @@ import lat.Lat;
 
 aspectdef tune_mm
 	var lat = new Lat("co_cilk");
-	
-	lat.setVerbose(true).loadCmaker().cmaker.setMakeCommand("nmake");
-	
+
+	lat.setVerbose(true).loadCmaker().cmaker.setGenerator("MinGW Makefiles").setMakeCommand("mingw32-make");
+	// lat.setVerbose(true).loadCmaker().cmaker.setMakeCommand("nmake");
+
 	//-----------------------------------------------First Tuning scope
 	//#pragma isat tuning name(co_cilk) scope(co_cilk_start, co_cilk_end) measure(start_timing, end_timing) variable(NPIECES, range(2, 8, 1)) variable(dx_threshold, range(200, 2000, 8)) variable(dy_threshold, range(2, 128, 2)) variable(dz_threshold, range(2, 128, 2)) variable(dt_threshold, range(2, 128, 2))
-	
+
 	select marker end
 	apply
 		if($marker.id == "co_cilk"){
-			lat.setScope($marker.contents); 
+			lat.setScope($marker.contents);
 		}else if($marker.id = "timing"){
-			lat.setMeasure($marker.contents); 
+			lat.setMeasure($marker.contents);
 		}
 		//optional exit option from select apply
 		if(lat.scope !== undefined && lat.measure !== undefined){
@@ -26,9 +27,9 @@ aspectdef tune_mm
 	var dx_threshold = new LatVarRange("dx_threshold", 200, 2000, 8);
 	var dy_threshold = new LatVarRange("dy_threshold", 2, 128, 2);
 	var dz_threshold = new LatVarRange("dz_threshold", 2, 128, 2);
-	
+
 	lat.setVariables([NPIECES, dt_threshold, dx_threshold, dy_threshold, dz_threshold]);
-	
+
 	lat.tune();
 
 	//-----------------------------------------------Second Tuning scope
@@ -39,11 +40,11 @@ aspectdef tune_mm
 	select marker end
 	apply
 		if($marker.id == "initCilk"){
-			lat.setScope($marker.contents); 
+			lat.setScope($marker.contents);
 			break;
 		}
 	end
-	
+
 	var nworkers_specified = new LatVarRange(1, LatConst.NUM_CPU_THREADS + 1, 1);
 
 	lat.setVariables([nworkers_specified]);

--- a/examples/BlockedMatrixMultiply/clava/blocked_mm.lara
+++ b/examples/BlockedMatrixMultiply/clava/blocked_mm.lara
@@ -3,8 +3,9 @@ import lat.Lat;
 aspectdef tune_mm
 	var lat = new Lat("blocked_mm");
 	
-	lat.setVerbose(true).loadCmaker().cmaker.setMakeCommand("nmake");
-	
+	lat.setVerbose(true).loadCmaker().cmaker.setGenerator("MinGW Makefiles").setMakeCommand("mingw32-make");
+	// lat.setVerbose(true).loadCmaker().cmaker.setMakeCommand("nmake");
+
 	select function end
 	apply
 		if($function.name == "BlockedMatrixMultiply"){

--- a/examples/GameOfLife/clava/game_of_life.lara
+++ b/examples/GameOfLife/clava/game_of_life.lara
@@ -3,7 +3,8 @@ import lat.Lat;
 aspectdef tune_mm
 	var lat = new Lat("region_1");
 	
-	lat.setVerbose(true).loadCmaker().cmaker.setMakeCommand("nmake");
+	lat.setVerbose(true).loadCmaker().cmaker.setGenerator("MinGW Makefiles").setMakeCommand("mingw32-make");
+	// lat.setVerbose(true).loadCmaker().cmaker.setMakeCommand("nmake");
 	
 	//-----------------------------------------------First Tuning scope
 	//#pragma isat tuning name(region_1) scope(M1_begin, M1_end) measure(M2_begin, M2_end) variable(x_blksize, range(100, 1000, 100)) variable(y_blksize, range(100, 1000, 100)) variable(num_threads, range(1, $NUM_CPU_THREADS + 1, 1))

--- a/examples/Omp/clava/omp.lara
+++ b/examples/Omp/clava/omp.lara
@@ -2,23 +2,23 @@ import lat.Lat;
 
 aspectdef tune_omp
 	var lat = new Lat("omp");
-	
-	lat.setVerbose(true).loadCmaker().cmaker.setMakeCommand("nmake");
-	lat.setOutputFolder("C:/Users/M/Desktop/Development/specs/LAT/lat/examples/Omp/Dst");
-	
+
+	lat.setVerbose(true).loadCmaker().cmaker.setGenerator("MinGW Makefiles").setMakeCommand("mingw32-make");
+	// lat.setVerbose(true).loadCmaker().cmaker.setMakeCommand("nmake");
+
 	select marker end
 	apply
 		if($marker.id == "OmpMeasure"){
 			lat.setScope($marker.contents);
 		}
 	end
-	
+
 	var omp_schedule_chunk = new LatVarRange("", 5, 10, 1, pow2);
 	var omp_num_threads = new LatVarRange("", 1, LatConst.NUM_CPU_THREADS);
 	var omp = new LatVarOmp("lat_omp", ["static", "dynamic", "guided"], omp_schedule_chunk, omp_num_threads);
 
 	lat.setSearchGroups([[omp]]);
-	
+
 	lat.tune();
 end
 

--- a/examples/Omp/clava/omp.lara
+++ b/examples/Omp/clava/omp.lara
@@ -4,6 +4,7 @@ aspectdef tune_omp
 	var lat = new Lat("omp");
 	
 	lat.setVerbose(true).loadCmaker().cmaker.setMakeCommand("nmake");
+	lat.setOutputFolder("C:/Users/M/Desktop/Development/specs/LAT/lat/examples/Omp/Dst");
 	
 	select marker end
 	apply

--- a/examples/SmartSearch/clava/smart_search.lara
+++ b/examples/SmartSearch/clava/smart_search.lara
@@ -1,0 +1,56 @@
+import lat.Lat;
+
+aspectdef tune_mm
+	var lat = new Lat("blocked_mm");
+
+	lat.setOutputFolder("C:/Users/M/Desktop/Development/specs/LAT/lat/examples/SmartSearch/Dst");
+	lat.setVerbose(true).loadCmaker().cmaker.setGenerator("MinGW Makefiles").setMakeCommand("mingw32-make");
+	// lat.setVerbose(true).loadCmaker().cmaker.setMakeCommand("nmake");
+
+	select marker end
+	apply
+		if($marker.id == "smartSearchTest"){
+			lat.setMeasure($marker.contents);
+			break;
+		}
+	end
+	var x = new LatVarRange("x", 1, 100, 10);
+	var y = new LatVarRange("y", 5, 21, 3);
+	lat.setVariables([x, y]);
+
+	//some metrics helper functions
+	function Metrics(){};
+	var metrics = new Metrics();
+	Metrics.prototype.restart = function(){
+		this.average = 0;
+		this.minDiff = Infinity;
+		this.count = 0;
+	};
+	Metrics.prototype.update = function(number){
+		var total = this.average * this.count + this.number;//undo the division and add the new number
+		var newAverage = total/(this.count++);//calculte new average
+		var diff = Math.abs(newAverage - this.average);//calculate current diff
+		this.average = average;//update the average
+		this.minDiff = Math.min(this.minDiff, diff);//update the minDiff
+	};
+
+	metrics.restart();
+	while (at.uniqueVariables.length > 0) {
+		lat.generateVariantSourceCode(0);
+		// var result = lat.executeVariant(0);
+		var result = (Math.random() * (0.5 - 1.8) + 1.8).toFixed(4);///TODO: replace with above
+		metrics.update(result);
+		if (metrics.minDiff < 0.01) {//example stop condition
+			break;
+		}else if(metrics.average > 1.23){//example stop condition
+			break;
+		}else if(metrics.average > 1){//filter example
+			lat.filterVariants(function(variant){
+				return variant[0].value < (metrics.count * 10) || variant[0].default == false;//filter out values greater than or equal to (metrics.count * 10) and default values
+			});
+		}
+		lat.removeVariant(0);
+	}
+
+	lat.tune();
+end

--- a/examples/SmartSearch/clava/smart_search.lara
+++ b/examples/SmartSearch/clava/smart_search.lara
@@ -10,7 +10,7 @@ aspectdef tune_mm
 	select marker end
 	apply
 		if($marker.id == "smartSearchTest"){
-			lat.setMeasure($marker.contents);
+			lat.setScope($marker.contents);
 			break;
 		}
 	end
@@ -19,38 +19,40 @@ aspectdef tune_mm
 	lat.setVariables([x, y]);
 
 	//some metrics helper functions
-	function Metrics(){};
-	var metrics = new Metrics();
-	Metrics.prototype.restart = function(){
+	function Metrics(){
 		this.average = 0;
 		this.minDiff = Infinity;
 		this.count = 0;
 	};
+	Metrics.prototype.restart = function(){
+	};
 	Metrics.prototype.update = function(number){
-		var total = this.average * this.count + this.number;//undo the division and add the new number
-		var newAverage = total/(this.count++);//calculte new average
+		var total = this.average * this.count + number;//undo the division and add the new number
+		this.count++;
+		var newAverage = total/this.count;//calculte new average
 		var diff = Math.abs(newAverage - this.average);//calculate current diff
-		this.average = average;//update the average
+		this.average = newAverage;//update the average
 		this.minDiff = Math.min(this.minDiff, diff);//update the minDiff
 	};
-
-	metrics.restart();
-	while (at.uniqueVariables.length > 0) {
-		lat.generateVariantSourceCode(0);
+	var metrics = new Metrics();
+	lat.prepareForTuning();
+	while (lat.uniqueVariants.length > 0) {
+		lat.generateVariantSourceCode(0);//TODO: replace with line below once execute variant returns a value
 		// var result = lat.executeVariant(0);
-		var result = (Math.random() * (0.5 - 1.8) + 1.8).toFixed(4);///TODO: replace with above
+		var result = (Math.random() * (1.6 - 0.5) + 0.5);
 		metrics.update(result);
-		if (metrics.minDiff < 0.01) {//example stop condition
+		print(metrics.average + "\n");
+		if (metrics.minDiff < 0.01) {//example single filter condition
+			lat.removeVariant(lat.uniqueVariants.length-1);//remove last
 			break;
-		}else if(metrics.average > 1.23){//example stop condition
+		}else if(metrics.average > 1.20){//example stop condition
 			break;
-		}else if(metrics.average > 1){//filter example
+		}else if(metrics.average > 1){//example multiple filter example
 			lat.filterVariants(function(variant){
 				return variant[0].value < (metrics.count * 10) || variant[0].default == false;//filter out values greater than or equal to (metrics.count * 10) and default values
 			});
 		}
 		lat.removeVariant(0);
 	}
-
-	lat.tune();
+	print("Done");
 end

--- a/examples/SmartSearch/src/smart_search.cpp
+++ b/examples/SmartSearch/src/smart_search.cpp
@@ -2,7 +2,7 @@
 
 int main() {
 	int a = 0;
-	#pragma lara marker smartSearchTest
+#pragma lara marker smartSearchTest
 	{
 		int x = 2000;
 		for(int i = 0; i < x % 20; i++){

--- a/examples/SmartSearch/src/smart_search.cpp
+++ b/examples/SmartSearch/src/smart_search.cpp
@@ -1,0 +1,19 @@
+#include <stdio.h>
+
+int main() {
+	int a = 0;
+	#pragma lara marker smartSearchTest
+	{
+		int x = 2000;
+		for(int i = 0; i < x % 20; i++){
+			int y = 1000 + x;
+			int z = x;
+			x = 6969;
+			for(int j = 0; j < x + y; j++){
+				printf("(%d,%d)", i, j);
+			}
+		}
+   	}
+
+	printf("Hello");
+}

--- a/lat/Lat.lara
+++ b/lat/Lat.lara
@@ -581,34 +581,7 @@ Lat.prototype.executeSourceCode = function() {
         this.print("Starting test " + (i + 1) + " of " + this.numTests + "...").pushIndent();
         for (var j = 0; j < this.uniqueVariants.length; j++) {
             this.print("Executing Variant " + (j + 1) + " of " + this.uniqueVariants.length + "...", true).pushIndent();
-
-			var command = this.uniqueVariants[j].executable;
-			if(this.executionFlags !== undefined) {
-				command += " " + this.executionFlags;
-			}
-
-            var executor = new ProcessExecutor();
-            var consoleOutput = executor.setPrintToConsole(false)
-                .setWorkingDir(this._variantsFolder + "/" + j)
-                .execute(command);
-
-			//debug("Executing '" + this.uniqueVariants[j].executable + " " + this.executionFlags);
-			//debug(consoleOutput);
-
-            this.popIndent().print("Done");
-
-			if(executor.getReturnValue() < 0) {
-				this.print("Execution returned value '" + executor.getReturnValue() +  " ' for command '" + command + "'\n");
-				if(!Strings.isEmpty(consoleOutput)) {
-					this.print("Output:");
-					this.print("#######");
-					this.print(consoleOutput);
-					this.print("#######\n");
-				}
-
-			}
-
-			//println("TEST:" + "Executing '" + this.uniqueVariants[j].executable + " " + this.executionFlags + "\n" + consoleOutput);
+            this.executeVariant(j);
         }
         this.popIndent().print("Done");
     }
@@ -617,6 +590,42 @@ Lat.prototype.executeSourceCode = function() {
         this.print("Clearing generated variants from your system...", true).pushIndent();
         Io.deleteFolder(this._variantsFolder);
         this.popIndent().print("Done");
+    }
+};
+/**
+ * Execute a single variant
+ * @param i the index of the variant to execute
+ * @param returnMetric boolean decidiing wether the measured metric of this variant should be returned
+ * @return the metric
+ */
+Lat.prototype.executeVariant = function(i, returnMetric) {
+    var variant = this.uniqueVariants[i];
+    var command = variant.executable;
+    if(this.executionFlags !== undefined) {
+        command += " " + this.executionFlags;
+    }
+
+    var executor = new ProcessExecutor();
+    var consoleOutput = executor.setPrintToConsole(false)
+        .setWorkingDir(this._variantsFolder + "/" + i)
+        .execute(command);
+
+    this.popIndent().print("Done");
+
+    if(executor.getReturnValue() < 0) {//if the execution fails
+        var userMessage = "Execution returned value '" + executor.getReturnValue() +  " ' for command '" + command + "'\n";
+        this.print(userMessage);
+        if(!Strings.isEmpty(consoleOutput)) {
+            this.print("Output:");
+            this.print("#######");
+            this.print(consoleOutput);
+            this.print("#######\n");
+        }
+        if (returnMetric) {
+            this._error(userMessage);
+        }
+    }else if(returnMetric){
+        //TODO: read the desired metric, this should be done in accordance to the way metrics will be gathered in the future
     }
 };
 

--- a/lat/Lat.lara
+++ b/lat/Lat.lara
@@ -686,6 +686,14 @@ Lat.prototype.getResults = function() {
     return LatUtils.clone(this.results);
 }
 
+/**
+ * Fitler the values inside this.uniqueVariants
+ * @param filterCallBack callback that should return true or false, where false means the variants that cause a false will bew removed
+ */
+Lat.prototype.filterVariants = function(filterCallBack) {
+    // this.uniqueVariants = this.uniqueVariants.filter(variant => filterCallBack(variant));
+}
+
 Lat.prototype.generateReport = function() {
     this.print("Generating the report...", true).pushIndent();
     if (Object.keys(this.results).length == 0) {

--- a/lat/Lat.lara
+++ b/lat/Lat.lara
@@ -73,12 +73,12 @@ Lat.prototype.tune = function() {
 
 	// Create results object
 	var parsedResults = this.buildResultsObject();
-	
+
     this._tuneCounts++; //update the current index of the tuning operation after the report generation
 
     this._tunned = true;
     this.popIndent().print("Tuning operation complete");
-	
+
 	return parsedResults;
 };
 
@@ -271,7 +271,7 @@ Lat.prototype.updatePathVariables = function() {
 	// Clear the variants folder, and recreate it
 	Io.deleteFolder(this._variantsFolder);
 	Io.mkdir(this._variantsFolder);
-	
+
     this._bestResult = this._resultsFolder + "/best"; /** the folder that will hold the best variant source code without timer prints */
     this._templateFolder = "../lat/templates/"; /** the file that will contain each tuning operation's report */
     this._reporterTemplate = "../lat/templates/report.html"; /** the file that will contain each tuning operation's report */
@@ -315,7 +315,7 @@ Lat.prototype.loadCmaker = function() {
  */
 Lat.prototype.validateProperty = function(propertyName, value, defaultValue) {
     /*TODO: use this[propertyName]
-    
+
     if (defaultValue === undefined && value === undefined) {
         LatUtils._error("The value specified for the property '" + propertyName + "' is undefined and it is a required property");
     }*/
@@ -406,7 +406,7 @@ Lat.prototype.generateSearchGroups = function() {
     return this;
 };
 /**
- * create a list of unique variables from search groups for the custom searchtype, or return this.variables for the other cases 
+ * create a list of unique variables from search groups for the custom searchtype, or return this.variables for the other cases
  */
 Lat.prototype.generateUniqueVariables = function() {
     this.print("Searching for Unique Variables...", true);
@@ -448,7 +448,7 @@ Lat.prototype.generateBaseVariant = function() {
  */
 Lat.prototype.generateUniqueVariants = function() {
     this.print("Generating Unique Variants...", true).pushIndent();
-    this.uniqueVariants = []; // a list 
+    this.uniqueVariants = []; // a list
     for (var i = 0; i < this.searchGroups.length; i++) {
         this.currentVariant = LatUtils.clone(this.baseVariant); //if this is not clone it's values will be changed
         this.generateVariantsRecursive(this.searchGroups[i], 0, i);
@@ -468,7 +468,7 @@ Lat.prototype.generateUniqueVariants = function() {
 };
 
 /**
- * 
+ *
  * @param searchGroup a list with the LatVars of the current searchGroup
  * @param index the current index being delt with, of searchGroup
  */
@@ -485,17 +485,17 @@ Lat.prototype.generateVariantsRecursive = function(searchGroup, index, searchGro
             this.currentVariant[searchGroup[index].index] = searchGroup[index].getNext(); //keep uniqueVariants order of elements the same as the order of unique Variants
 			var currentLatVarsCopy = currentLatVars.slice();
 			currentLatVarsCopy.push(searchGroup[index]);
-            
-			
+
+
 			this.generateVariantsRecursive(searchGroup, index + 1, searchGroupIndex, currentLatVarsCopy); //next LatVar in the searchGroup
         } else {
 			//var isFirst = true;
             while (searchGroup[index].hasNext()) {
-				
+
                 this.currentVariant[searchGroup[index].index] = searchGroup[index].getNext(); //only update the value
 				var currentLatVarsCopy = currentLatVars.slice();
 				currentLatVarsCopy.push(searchGroup[index]);
-			  /*  
+			  /*
 				// Skip first
 				if(isFirst) {
 					println("SKIPPING FIRST!");
@@ -503,7 +503,7 @@ Lat.prototype.generateVariantsRecursive = function(searchGroup, index, searchGro
 					continue;
 				}
 */
-				
+
 				this.uniqueVariants.push({
                     variant: LatUtils.clone(this.currentVariant),
 					latvars: currentLatVarsCopy,
@@ -523,46 +523,54 @@ Lat.prototype.generateSourceCode = function() {
     //0 check if any includes are necessary
     this.checkIncludes();
 
-    var countVarsPerVariant = this.uniqueVariables.length; //avoid multiple accesses
     for (var i = 0; i < this.uniqueVariants.length; i++) { //foreach variant
         this.print("Generating for Variant " + (i + 1) + " of " + this.uniqueVariants.length + "...", true).pushIndent();
-        Clava.pushAst(); //preserve the initial ast before changing it : LowLevelApi.getNode(this.scope).hashCode()
-        // Find equivalent join points
-        var $eqScope = LatUtils.findNewJp(this.scope);
-        var $eqMeasure = LatUtils.findNewJp(this.measure);
-
-        //1st alter  the value of all variables according to the current variant
-        for (var j = 0; j < countVarsPerVariant; j++) { //foreach variable in the current variant
-            if (!this.uniqueVariants[i].variant[j].default) { //only edit if the default value is not selected
-
-                var callOutput = undefined;
-                if (!LatUtils.isLatVarOmp(this.uniqueVariables[j])) { //omp does not use vardecl nor varref
-                    if ($eqScope.instanceOf("scope")) {
-                        call callOutput: getJoinpointsToChangeForSingleLatVarScope($eqScope, this.uniqueVariables[j]);
-                    } else {
-                        call callOutput: getJoinpointsToChangeForSingleLatVar($eqScope, this.uniqueVariables[j]);
-                    }
-                } else {
-                    call callOutput: getJoinpointsToChangeForLatVarOmp(this.uniqueVariables[j]);
-                }
-                this.uniqueVariables[j] = callOutput.latvarOut;
-				this.uniqueVariables[j].changeVariantInAst($eqScope, this.uniqueVariants[i].variant[j], this.conservativeReplacement); //update the AST with the current value for this LatVar's variant
-            }
-        }
-        //2nd include the timer prints
-        var timer = new Timer("NANOSECONDS", this._timerFileAbsolute);
-        timer.time($eqMeasure, this.getTuneName() + " " + i + " ");
-
-        //3rd write the variant to the output folder
-        Clava.writeCode(this._variantsFolder + "/" + i);
-
-        //4th use CMaker
-        this.uniqueVariants[i].executable = this.generateExecutable(i); //save the executable
-
-        Clava.popAst(); //retrieve the initial ast after changing it, to allow multiple changes
+        this.generateVariantSourceCode(i);
         this.popIndent().print("Done", true).print();
     }
     this.popIndent().print("Done", true).print();
+};
+
+/**
+ * Generate and compile the source code for the variant at index i
+ * @param i the index in this.uniqueVariants of the variant to generate
+ */
+Lat.prototype.generateVariantSourceCode = function(i) {
+    Clava.pushAst(); //preserve the initial ast before changing it : LowLevelApi.getNode(this.scope).hashCode()
+    var variant = this.uniqueVariants[i];
+    // Find equivalent join points
+    var $eqScope = LatUtils.findNewJp(this.scope);
+    var $eqMeasure = LatUtils.findNewJp(this.measure);
+
+    //1st alter  the value of all variables according to the current variant
+    for (var j = 0; j < this.uniqueVariables.length; j++) { //foreach variable in the current variant
+        if (!variant.variant[j].default) { //only edit if the default value is not selected
+
+            var callOutput = undefined;
+            if (!LatUtils.isLatVarOmp(this.uniqueVariables[j])) { //omp does not use vardecl nor varref
+                if ($eqScope.instanceOf("scope")) {
+                    call callOutput: getJoinpointsToChangeForSingleLatVarScope($eqScope, this.uniqueVariables[j]);
+                } else {
+                    call callOutput: getJoinpointsToChangeForSingleLatVar($eqScope, this.uniqueVariables[j]);
+                }
+            } else {
+                call callOutput: getJoinpointsToChangeForLatVarOmp(this.uniqueVariables[j]);
+            }
+            this.uniqueVariables[j] = callOutput.latvarOut;
+            this.uniqueVariables[j].changeVariantInAst($eqScope, variant.variant[j], this.conservativeReplacement); //update the AST with the current value for this LatVar's variant
+        }
+    }
+    //2nd include the timer prints
+    var timer = new Timer("NANOSECONDS", this._timerFileAbsolute);
+    timer.time($eqMeasure, this.getTuneName() + " " + i + " ");
+
+    //3rd write the variant to the output folder
+    Clava.writeCode(this._variantsFolder + "/" + i);
+
+    //4th use CMaker
+    variant.executable = this.generateExecutable(i); //save the executable
+
+    Clava.popAst(); //retrieve the initial ast after changing it, to allow multiple changes
 };
 
 /**
@@ -585,10 +593,10 @@ Lat.prototype.executeSourceCode = function() {
                 .execute(command);
 
 			//debug("Executing '" + this.uniqueVariants[j].executable + " " + this.executionFlags);
-			//debug(consoleOutput);	
-				
+			//debug(consoleOutput);
+
             this.popIndent().print("Done");
-			
+
 			if(executor.getReturnValue() < 0) {
 				this.print("Execution returned value '" + executor.getReturnValue() +  " ' for command '" + command + "'\n");
 				if(!Strings.isEmpty(consoleOutput)) {
@@ -596,10 +604,10 @@ Lat.prototype.executeSourceCode = function() {
 					this.print("#######");
 					this.print(consoleOutput);
 					this.print("#######\n");
-				}				
-				
+				}
+
 			}
-			
+
 			//println("TEST:" + "Executing '" + this.uniqueVariants[j].executable + " " + this.executionFlags + "\n" + consoleOutput);
         }
         this.popIndent().print("Done");
@@ -624,7 +632,7 @@ Lat.prototype.parseResults = function(emptyFileAfterwards) {
 		//if(lines[i].trim().length() === 0) {
 		//	continue;
 		//}
-		
+
         //parse one line from the timer file into variables
         //format: tuneName variant time
         var parts = lines[i].split(" "); // 0 -> [name]_[index], 1->[variant]_[index], 2->[time]ns
@@ -738,15 +746,15 @@ Lat.prototype.generateExecutable = function(i) {
     }
 
     var executable = this.cmaker.build(this._variantsFolder + "/" + i, buildFolder);
-	
+
 	if(executable === undefined) {
 		var msg = "[LAT] Could not generate executable";
 		if(!Strings.isEmpty(this.cmaker.getMakeOutput())) {
 			msg += ": " + this.cmaker.getMakeOutput();
-		}		
+		}
 		println(msg);
 	}
-	
+
 	return executable;
 };
 
@@ -754,7 +762,7 @@ Lat.prototype.buildResultsObject = function() {
 
 	// start creating the object
 	var results = {};
-	
+
 	results.name = this.name;
 	results.variants = [];
 
@@ -762,14 +770,14 @@ Lat.prototype.buildResultsObject = function() {
 
 	var tuneResults = this.results[tuneName];
 	var variants = tuneResults["per_variant"];
-	
+
 	for(var variantIndex in variants) {
 
 		var variant = {};
 
 		var variantArray = this.uniqueVariants[variantIndex].variant;
 		var latvars = this.uniqueVariants[variantIndex].latvars;
-		
+
 		if(variantArray.length !== latvars.length) {
 			throw "Expected variants to be the same length (" + variantArray.length + ") as latvars (" + latvars.length + ")";
 		}
@@ -782,17 +790,17 @@ Lat.prototype.buildResultsObject = function() {
 			variant.nameArray = variant.nameArray.concat(latvar.getNameArray());
 			variant.valueArray = variant.valueArray.concat(latvar.getValueArray(currentVariant));
 		}
-		
-		variant.metrics = [];		
 
-		
+		variant.metrics = [];
+
+
 		// For now, assume a single metric (time in ns)
 		var timeMetric = {};
 		timeMetric.name = "Execution Time";
 		timeMetric.unit = "ns";
 		timeMetric.values = variants[variantIndex].times;
-		
-		variant.metrics.push(timeMetric);	
+
+		variant.metrics.push(timeMetric);
 
 		results.variants.push(variant);
 	}

--- a/lat/Lat.lara
+++ b/lat/Lat.lara
@@ -694,6 +694,14 @@ Lat.prototype.filterVariants = function(filterCallBack) {
     // this.uniqueVariants = this.uniqueVariants.filter(variant => filterCallBack(variant));
 }
 
+/**
+ * Remove a variant from the list, by index
+ * @param index the index at which to remove
+ */
+Lat.prototype.removeVariant = function(index) {
+    this.uniqueVariants.splice(index);
+}
+
 Lat.prototype.generateReport = function() {
     this.print("Generating the report...", true).pushIndent();
     if (Object.keys(this.results).length == 0) {

--- a/lat/Lat.lara
+++ b/lat/Lat.lara
@@ -37,18 +37,18 @@ var Lat = function(name, scope, variables, measure, searchType, numTests, remove
 	//this.skipDefaultCases = true;
 };
 
-Lat.prototype.tune = function() {
-    this.restartPrintLog();
-    this.print("Starting tuning operation").pushIndent();
-    this._tunned = false;
-    this._duration = System.nanos(); //tune start time, duration will be calculated later
-
+/**
+ * Run the necessary checks and generate variants
+ */
+Lat.prototype.prepareForTuning = function(){
     //check cmake options
     this.checkCmakerOptions();
 
+    //remove duplicates
     if (this.searchType === LatConst.SEARCH_TYPE.DEPENDENT || this.searchType === LatConst.SEARCH_TYPE.INDEPENDENT) {
         this.variables = LatUtils.removeDuplicates(this.variables);
     }
+    //generate the variants
     this.generateSearchGroups();
     this.generateUniqueVariables();
     this.generateBaseVariant(); //must come after generateUniqueVariables
@@ -58,11 +58,18 @@ Lat.prototype.tune = function() {
         return;
     }
 
-
     this.checkVariablesInScope();
     if (Io.readFile(this._timerFile) == null) {
         Io.writeFile(this._timerFile, "\n"); //create the file if it does not exist
     }
+}
+Lat.prototype.tune = function() {
+    this.restartPrintLog();
+    this.print("Starting tuning operation").pushIndent();
+    this._tunned = false;
+    this._duration = System.nanos(); //tune start time, duration will be calculated later
+
+    this.prepareForTuning();
 
     this.generateSourceCode();
     this.executeSourceCode();

--- a/lat/LatVarRange.lara
+++ b/lat/LatVarRange.lara
@@ -70,4 +70,4 @@ LatVarRange.prototype.newTemplateCard = function() {
     replacerCard.replaceAll("[[step]]", this.step);
 		
 	return replacerCard;
-}
+};


### PR DESCRIPTION
# Flexible tuning in LAT
This changes allow the use of lat as a flexible tool.
Allowing the generation and/or execution of single variants, with:

```javascript
lat.prepareForTuning();//generate the variants for further exploration
lat.generateVariantSourceCode(index); //generate and compile the source code for the variant at index
var result = lat.executeVariant(index);//execute the variant at index and return the specified metric (todo when multiple metrics integration is achieved)
lat.removeVariant(index);//remove an undesirable variant form the list of variants to process
lat.filterVariants(function(variant){//allows variants that do not respect the rule to be excluded
  return variant[0].value < (metrics.count * 10) || variant[0].default == false;
});
```

An example can be seen in the 📁 SmartSearch example.
